### PR TITLE
disable creation of orgs for registered users

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ CKAN_SITE_URL=http://localhost:5500
 CKAN__CORS__ORIGIN_WHITELIST=http://localhost:4200
 CKAN_PORT=5000
 CKAN___BEAKER__SESSION__SECRET=CHANGE_ME
+CKAN__AUTH__USER_CREATE_ORGANIZATIONS=false
 # See https://docs.ckan.org/en/latest/maintaining/configuration.html#api-token-settings
 CKAN___API_TOKEN__JWT__ENCODE__SECRET=string:CHANGE_ME
 CKAN___API_TOKEN__JWT__DECODE__SECRET=string:CHANGE_ME


### PR DESCRIPTION
- Registered users by default have read only access
- They can be added to an organisation by admins and there based on their role, they can do certain things
- The only default loophole present for registered users are that they can create new organizations themselves and within that oorganization, they can create datasets
- I disabled it using `ckan.auth.user_create_organizations` property
- We will still need to make sure that we set this env variable `CKAN__AUTH__USER_CREATE_ORGANIZATIONS` on production environment. Another alternative would be to use init script. I'm open to discuss

Prod PR
https://github.com/GenomicDataInfrastructure/gdi-userportal-ckan-deployment/pull/10