### PR TITLE
fix: user permissions error causes oidc plugin to error

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -67,4 +67,5 @@ COPY  --chown=ckan:ckan setup/prerun.py ${APP_DIR}
 # 1. Remove this command once the issue is fixed
 # https://github.com/ckan/ckan-docker-base/issues/41
 RUN mkdir -p /var/lib/ckan/storage/uploads/group && \
+    mkdir -p /var/lib/ckan/storage/uploads/user && \
     chmod -R u+rwx "/var/lib/ckan"


### PR DESCRIPTION
The same problem with the groups directory (issue https://github.com/ckan/ckan-docker-base/issues/41) also occurs with the user directory. This is mainly exhibited when trying to login using the oidc_pkce plugin with a user account that does not yet exist CKAN.