### PR TITLE
feat(scheming): set up GDI presets (for datetime scheming)

### DIFF
--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -61,4 +61,5 @@ ENV CKAN__PLUGINS="envvars image_view text_view recline_view scheming_datasets s
 COPY  --chown=ckan:ckan setup/prerun.py ${APP_DIR}
 
 RUN mkdir -p /var/lib/ckan/storage/uploads/group && \
+    mkdir -p /var/usr/ckan/storage/uploads/user && \
     chmod -R u+rwx "/var/lib/ckan"

--- a/ckan/docker-entrypoint.d/setup_scheming.sh
+++ b/ckan/docker-entrypoint.d/setup_scheming.sh
@@ -7,8 +7,8 @@
 # Update the config file with each extension config-options
 echo "[ckanext-scheming] Setting up config-options"
 ckan config-tool $CKAN_INI -s app:main \
-    "scheming.dataset_schemas = ckanext.gdi_userportal:scheming/schemas/gdi_userportal.json"\
-    "scheming.presets = ckanext.scheming:presets.json"\
-    "scheming.dataset_fallback = false"\
-    "ckanext.dcat.rdf.profiles = euro_dcat_ap_2 fairdatapoint_dcat_ap"\
+    "scheming.dataset_schemas = ckanext.gdi_userportal:scheming/schemas/gdi_userportal.json" \
+    "scheming.presets = ckanext.scheming:presets.json ckanext.gdi_userportal:scheming/presets/gdi_presets.json" \
+    "scheming.dataset_fallback = false" \
+    "ckanext.dcat.rdf.profiles = euro_dcat_ap_2 fairdatapoint_dcat_ap" \
     "ckanext.dcat.compatibility_mode = false"


### PR DESCRIPTION
For use in conjunction with https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-gdi-userportal/pull/90 and https://github.com/GenomicDataInfrastructure/gdi-userportal-dataset-discovery-service/pull/108

Before merging we'll need a plan to merge/release these all simulteaneously, as they got dependencies on each other.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Set up GDI presets for datetime scheming by updating the CKAN configuration to include new preset paths.

New Features:
- Introduce GDI presets for datetime scheming in the CKAN configuration.

<!-- Generated by sourcery-ai[bot]: end summary -->