### PR TITLE
Revert "chore(deps): update docker.io/ckan/ckan-dev docker tag to v2.11.0"

### DIFF
--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-FROM docker.io/ckan/ckan-dev:2.11.0
+FROM docker.io/ckan/ckan-dev:2.10.5
 
 RUN  pip3 install -e git+https://github.com/ckan/ckanext-dcat.git@v2.0.0#egg=ckanext-dcat && \
     pip3 install -r ${APP_DIR}/src/ckanext-dcat/requirements.txt


### PR DESCRIPTION
Reverts GenomicDataInfrastructure/gdi-userportal-ckan-docker#133

We need to test our extensions to ensure 2.11 is compatible.