### PR TITLE
Revert "chore(deps): update docker.io/ckan/ckan-base docker tag to v2.11.0"

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-FROM docker.io/ckan/ckan-base:2.11.0
+FROM docker.io/ckan/ckan-base:2.10.5
 
 RUN  pip3 install -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-gdi-userportal.git@v1.3.1#egg=ckanext-gdi-userportal && \
     pip3 install -r ${APP_DIR}/src/ckanext-gdi-userportal/requirements.txt


### PR DESCRIPTION
Reverts GenomicDataInfrastructure/gdi-userportal-ckan-docker#132