### PR TITLE
Prepare for release v1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [v1.3.3] - 2024-10-16
+
+### Fixed
+* fix(language): Set fallback languageto English when Dutch for example is not available
+
 ## [v1.3.2] - 2024-10-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v1.3.3] - 2024-10-16
 
 ### Fixed
-* fix(language): Set fallback languageto English when Dutch for example is not available
+* fix(language): Set fallback language to English when Dutch for example is not available
 
 ## [v1.3.2] - 2024-10-14
 

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -6,7 +6,7 @@
 
 FROM docker.io/ckan/ckan-base:2.10.5
 
-RUN  pip3 install -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-gdi-userportal.git@v1.3.3#egg=ckanext-gdi-userportal && \
+RUN  pip3 install -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-gdi-userportal.git@v1.3.4#egg=ckanext-gdi-userportal && \
     pip3 install -r ${APP_DIR}/src/ckanext-gdi-userportal/requirements.txt
 
 RUN  pip3 install -e git+https://github.com/ckan/ckanext-dcat.git@v2.0.0#egg=ckanext-dcat && \


### PR DESCRIPTION
## Summary by Sourcery

Prepare for release v1.3.3 by updating the CHANGELOG with a bug fix that sets the fallback language to English when a specified language is unavailable.

Bug Fixes:
- Fix fallback language setting to default to English when a specified language, such as Dutch, is unavailable.

Documentation:
- Update CHANGELOG.md to include details of the bug fix in version v1.3.3.