### PR TITLE
fix typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v1.3.3] - 2024-10-16
 
 ### Fixed
-* fix(language): Set fallback languageto English when Dutch for example is not available
+* fix(language): Set fallback language to English when Dutch for example is not available
 
 ## [v1.3.2] - 2024-10-14
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct a typo in the CHANGELOG.md file regarding the fallback language setting.