### PR TITLE
fix: reuse CKAN_SQLALCHEMY_URL in upload_vocabulary.sh

### DIFF
--- a/ckan/docker-entrypoint.d/upload_vocabulary.sh
+++ b/ckan/docker-entrypoint.d/upload_vocabulary.sh
@@ -6,7 +6,7 @@
 
 set -e
 
-psql postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@$POSTGRES_HOST:5432/$CKAN_DB <<-EOSQL
+psql $CKAN_SQLALCHEMY_URL <<-EOSQL
 
   SELECT
       EXISTS(SELECT 1 FROM public.term_translation) as table_not_empty


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix the database connection string in upload_vocabulary.sh to use CKAN_SQLALCHEMY_URL instead of constructing it manually.