### PR TITLE
chore(deps): revert CKAN upgrade

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-FROM docker.io/ckan/ckan-base:2.10.6
+FROM docker.io/ckan/ckan-base:2.10.5
 
 RUN  pip3 install -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-gdi-userportal.git@v1.3.8#egg=ckanext-gdi-userportal && \
     pip3 install -r ${APP_DIR}/src/ckanext-gdi-userportal/requirements.txt

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-FROM docker.io/ckan/ckan-dev:2.10.6
+FROM docker.io/ckan/ckan-dev:2.10.5
 
 RUN  pip3 install -e git+https://github.com/ckan/ckanext-dcat.git@v2.1.0#egg=ckanext-dcat && \
     pip3 install -r ${APP_DIR}/src/ckanext-dcat/requirements.txt


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Revert CKAN base image version from 2.10.6 to 2.10.5 in Dockerfile.