### PR TITLE
chore(deps): upgrade CKAN to 2.10.6

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-FROM docker.io/ckan/ckan-base:2.10.5
+FROM docker.io/ckan/ckan-base:2.10.6
 
 RUN  pip3 install -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-gdi-userportal.git@v1.3.8#egg=ckanext-gdi-userportal && \
     pip3 install -r ${APP_DIR}/src/ckanext-gdi-userportal/requirements.txt

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-FROM docker.io/ckan/ckan-dev:2.10.5
+FROM docker.io/ckan/ckan-dev:2.10.6
 
 RUN  pip3 install -e git+https://github.com/ckan/ckanext-dcat.git@v2.1.0#egg=ckanext-dcat && \
     pip3 install -r ${APP_DIR}/src/ckanext-dcat/requirements.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ volumes:
   ckan_storage:
   pg_data:
   solr_data:
-  pip_cache:
   site_packages:
 
 services:
@@ -29,7 +28,6 @@ services:
     volumes:
       - ckan_storage:/var/lib/ckan
       - ./src:/srv/app/src_extensions
-      - pip_cache:/root/.cache/pip
       - site_packages:/usr/lib/python3.10/site-packages
     restart: unless-stopped
     healthcheck:


### PR DESCRIPTION
## Summary by Sourcery

Upgrade CKAN to version 2.10.6 and remove the 'pip_cache' volume from the docker-compose configuration.

Build:
- Remove the 'pip_cache' volume from the docker-compose.yml file.

Chores:
- Upgrade CKAN base image from version 2.10.5 to 2.10.6 in the Dockerfile.