### PR TITLE
chore: upgrade extension version

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -6,7 +6,7 @@
 
 FROM docker.io/ckan/ckan-base:2.10.6
 
-RUN  pip3 install -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-gdi-userportal.git@v1.3.8#egg=ckanext-gdi-userportal && \
+RUN  pip3 install -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-gdi-userportal.git@v1.3.9#egg=ckanext-gdi-userportal && \
     pip3 install -r ${APP_DIR}/src/ckanext-gdi-userportal/requirements.txt
 
 RUN  pip3 install -e git+https://github.com/ckan/ckanext-dcat.git@v2.1.0#egg=ckanext-dcat && \


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Upgrade ckanext-gdi-userportal from v1.3.8 to v1.3.9.