### PR TITLE
fix(redis): remove unnecessary redis password  in environment file

### DIFF
--- a/.env
+++ b/.env
@@ -52,7 +52,7 @@ CKAN__PLUGINS="envvars scheming_datasets scheming_organizations gdi_userportal d
 CKAN__HARVEST__MQ__HOSTNAME=redis
 CKAN__HARVEST__MQ__PORT=6379
 CKAN__HARVEST__MQ__REDIS_DB=1
-CKAN__HARVEST__MQ__PASSWORD=redis
+CKAN__HARVEST__MQ__PASSWORD=
 CKAN__HARVEST__MQ__TYPE=redis
 
 #Logger

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ To start the containers:
 ```bash
 	bin/compose up
 ```
+Shut down and restart the whole ckan-dev container (use bin/compose up -d instead to reload new values from .env)
+```bash
+	bin/compose restart
+```
+
 ### 3.2. Remove images and volumes
 ```bash
   bin/compose down -v

--- a/bin/ckan
+++ b/bin/ckan
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: 2006-2024 Open Knowledge Foundation and contributors
+# SPDX-FileCopyrightText: Stichting Health-RI
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
 set -e
 ROOT="$(dirname ${BASH_SOURCE[0]})/.."
 
-docker compose -f "${ROOT}/docker-compose.dev.yml" exec ckan-dev ckan "$@"
+docker compose -f "${ROOT}/docker-compose.yml" exec ckan-dev ckan "$@"

--- a/bin/compose
+++ b/bin/compose
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: 2006-2024 Open Knowledge Foundation and contributors
+# SPDX-FileCopyrightText: Stichting Health-RI
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/bin/install_src
+++ b/bin/install_src
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: 2006-2024 Open Knowledge Foundation and contributors
+# SPDX-FileCopyrightText: Stichting Health-RI
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 

--- a/bin/restart
+++ b/bin/restart
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# SPDX-FileCopyrightText: Stichting Health-RI
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
 set -e
 ROOT="$(dirname ${BASH_SOURCE[0]})/.."
 

--- a/bin/restart
+++ b/bin/restart
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+ROOT="$(dirname ${BASH_SOURCE[0]})/.."
+
+docker compose -f "${ROOT}/docker-compose.yml" restart ckan-dev


### PR DESCRIPTION
- Removed value of `CKAN__HARVEST__MQ__PASSWORD` environment file
- Added `restart` script for seamless restarts after updating environment variables.

## Summary by Sourcery

Remove the Redis password from the environment file and add a restart script for seamless restarts after updating environment variables.

Build:
- Add a restart script to shut down and restart the whole ckan-dev container.

Chores:
- Remove the value of `CKAN__HARVEST__MQ__PASSWORD` from the environment file.