### PR TITLE
chore(deps): upgrade CKAN

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -13,7 +13,7 @@ USER ckan
 RUN pip3 install -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-gdi-userportal.git@v1.3.10#egg=ckanext-gdi-userportal && \
     pip3 install -r ${APP_DIR}/src/ckanext-gdi-userportal/requirements.txt
 
-RUN pip3 install -e git+https://github.com/ckan/ckanext-dcat.git@v2.1.0#egg=ckanext-dcat && \
+RUN pip3 install -e git+https://github.com/ckan/ckanext-dcat.git@v2.2.0#egg=ckanext-dcat && \
     pip3 install -r ${APP_DIR}/src/ckanext-dcat/requirements.txt
 
 RUN pip3 install -e git+https://github.com/ckan/ckanext-harvest.git@v1.6.0#egg=ckanext-harvest && \

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -10,7 +10,7 @@ USER root
 RUN chown -R ckan:ckan-sys ${APP_DIR}
 USER ckan
 
-RUN pip3 install -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-gdi-userportal.git@v1.3.10#egg=ckanext-gdi-userportal && \
+RUN pip3 install -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-gdi-userportal.git@v1.3.11#egg=ckanext-gdi-userportal && \
     pip3 install -r ${APP_DIR}/src/ckanext-gdi-userportal/requirements.txt
 
 RUN pip3 install -e git+https://github.com/ckan/ckanext-dcat.git@v2.2.0#egg=ckanext-dcat && \

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-FROM ckan/ckan-base:2.11.1
+FROM ckan/ckan-base:2.11.2
 
 USER root
 RUN chown -R ckan:ckan-sys ${APP_DIR}

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-FROM ckan/ckan-dev:2.11.1
+FROM ckan/ckan-dev:2.11.2
 
 USER root
 RUN chown -R ckan:ckan-sys ${APP_DIR}

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -11,7 +11,7 @@ RUN chown -R ckan:ckan-sys ${APP_DIR}
 USER ckan
 
 
-RUN pip3 install -e git+https://github.com/ckan/ckanext-dcat.git@v2.1.0#egg=ckanext-dcat && \
+RUN pip3 install -e git+https://github.com/ckan/ckanext-dcat.git@v2.2.0#egg=ckanext-dcat && \
     pip3 install -r ${APP_DIR}/src/ckanext-dcat/requirements.txt
 
 RUN pip3 install -e git+https://github.com/ckan/ckanext-harvest.git@v1.6.0#egg=ckanext-harvest && \


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update CKAN base image from 2.11.1 to 2.11.2 in Dockerfile and Dockerfile.dev.