### PR TITLE
Health dcat fdp

### DIFF
--- a/.env
+++ b/.env
@@ -48,7 +48,7 @@ CKAN_REDIS_URL=redis://redis:6379/1
 CKAN_SOLR_URL=http://solr:8983/solr/ckan
 
 # Extensions
-CKAN__PLUGINS="envvars dataset_series scheming_datasets scheming_organizations gdi_userportal gdi_userportalharvester dcat dcat_json_interface harvest ckan_harvester dcat_rdf_harvester dcat_json_harvester fairdatapointharvester activity"
+CKAN__PLUGINS="envvars scheming_datasets scheming_organizations gdi_userportal gdi_userportalharvester dcat dcat_json_interface harvest ckan_harvester dcat_rdf_harvester dcat_json_harvester fairdatapointharvester activity"
 CKAN__HARVEST__MQ__HOSTNAME=redis
 CKAN__HARVEST__MQ__PORT=6379
 CKAN__HARVEST__MQ__REDIS_DB=1

--- a/.env
+++ b/.env
@@ -48,7 +48,7 @@ CKAN_REDIS_URL=redis://redis:6379/1
 CKAN_SOLR_URL=http://solr:8983/solr/ckan
 
 # Extensions
-CKAN__PLUGINS="envvars scheming_datasets scheming_organizations gdi_userportal gdi_userportalharvester dcat dcat_json_interface harvest ckan_harvester dcat_rdf_harvester dcat_json_harvester fairdatapointharvester activity"
+CKAN__PLUGINS="envvars dataset_series scheming_datasets scheming_organizations gdi_userportal gdi_userportalharvester dcat dcat_json_interface harvest ckan_harvester dcat_rdf_harvester dcat_json_harvester fairdatapointharvester activity"
 CKAN__HARVEST__MQ__HOSTNAME=redis
 CKAN__HARVEST__MQ__PORT=6379
 CKAN__HARVEST__MQ__REDIS_DB=1

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -13,9 +13,6 @@ USER ckan
 RUN pip3 install -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-gdi-userportal.git@v1.3.11#egg=ckanext-gdi-userportal && \
     pip3 install -r ${APP_DIR}/src/ckanext-gdi-userportal/requirements.txt
 
-RUN pip3 install -e git+https://github.com/ckan/ckanext-dataset-series.git@main#egg=ckanext-dataset-series && \
-    pip3 install -r ${APP_DIR}/src/ckanext-dataset-series/requirements.txt
-
 RUN pip3 install -e git+https://github.com/ckan/ckanext-dcat.git@v2.2.0#egg=ckanext-dcat && \
     pip3 install -r ${APP_DIR}/src/ckanext-dcat/requirements.txt
 
@@ -24,7 +21,7 @@ RUN pip3 install -e git+https://github.com/ckan/ckanext-harvest.git@v1.6.0#egg=c
 
 RUN pip3 install -e git+https://github.com/CivityNL/ckanext-scheming.git@release-3.0.0-civity-1#egg=ckanext-scheming[requirements]
 
-RUN pip3 install -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-fairdatapoint.git@v1.3.2#egg=ckanext-fairdatapoint && \
+RUN pip3 install -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-fairdatapoint.git@v1.3.3#egg=ckanext-fairdatapoint && \
     pip3 install -r ${APP_DIR}/src/ckanext-fairdatapoint/requirements.txt
 
 USER root

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -13,6 +13,9 @@ USER ckan
 RUN pip3 install -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-gdi-userportal.git@v1.3.10#egg=ckanext-gdi-userportal && \
     pip3 install -r ${APP_DIR}/src/ckanext-gdi-userportal/requirements.txt
 
+RUN pip3 install -e git+https://github.com/ckan/ckanext-dataset-series.git@main#egg=ckanext-dataset-series && \
+    pip3 install -r ${APP_DIR}/src/ckanext-dataset-series/requirements.txt
+
 RUN pip3 install -e git+https://github.com/ckan/ckanext-dcat.git@v2.2.0#egg=ckanext-dcat && \
     pip3 install -r ${APP_DIR}/src/ckanext-dcat/requirements.txt
 

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -14,12 +14,15 @@ USER ckan
 RUN pip3 install -e git+https://github.com/ckan/ckanext-dcat.git@v2.2.0#egg=ckanext-dcat && \
     pip3 install -r ${APP_DIR}/src/ckanext-dcat/requirements.txt
 
+RUN pip3 install -e git+https://github.com/ckan/ckanext-dataset-series.git@main#egg=ckanext-dataset-series && \
+    pip3 install -r ${APP_DIR}/src/ckanext-dataset-series/requirements.txt
+
 RUN pip3 install -e git+https://github.com/ckan/ckanext-harvest.git@v1.6.0#egg=ckanext-harvest && \
     pip3 install -r ${APP_DIR}/src/ckanext-harvest/requirements.txt
 
 RUN pip3 install -e git+https://github.com/CivityNL/ckanext-scheming.git@release-3.0.0-civity-1#egg=ckanext-scheming[requirements]    
 
-RUN pip3 install -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-fairdatapoint.git@v1.3.2#egg=ckanext-fairdatapoint && \
+RUN pip3 install -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-fairdatapoint.git@dcat-2.2.0#egg=ckanext-fairdatapoint && \
     pip3 install -r ${APP_DIR}/src/ckanext-fairdatapoint/requirements.txt
 
 USER root

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -14,15 +14,12 @@ USER ckan
 RUN pip3 install -e git+https://github.com/ckan/ckanext-dcat.git@v2.2.0#egg=ckanext-dcat && \
     pip3 install -r ${APP_DIR}/src/ckanext-dcat/requirements.txt
 
-RUN pip3 install -e git+https://github.com/ckan/ckanext-dataset-series.git@main#egg=ckanext-dataset-series && \
-    pip3 install -r ${APP_DIR}/src/ckanext-dataset-series/requirements.txt
-
 RUN pip3 install -e git+https://github.com/ckan/ckanext-harvest.git@v1.6.0#egg=ckanext-harvest && \
     pip3 install -r ${APP_DIR}/src/ckanext-harvest/requirements.txt
 
 RUN pip3 install -e git+https://github.com/CivityNL/ckanext-scheming.git@release-3.0.0-civity-1#egg=ckanext-scheming[requirements]    
 
-RUN pip3 install -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-fairdatapoint.git@dcat-2.2.0#egg=ckanext-fairdatapoint && \
+RUN pip3 install -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-fairdatapoint.git@v1.3.3#egg=ckanext-fairdatapoint && \
     pip3 install -r ${APP_DIR}/src/ckanext-fairdatapoint/requirements.txt
 
 USER root

--- a/ckan/docker-entrypoint.d/setup_scheming.sh
+++ b/ckan/docker-entrypoint.d/setup_scheming.sh
@@ -7,10 +7,10 @@
 # Update the config file with each extension config-options
 echo "[ckanext-scheming] Setting up config-options"
 ckan config-tool $CKAN_INI -s app:main \
-    "scheming.dataset_schemas = ckanext.dcat.schemas:dcat_ap_full.yaml ckanext.gdi_userportal:scheming/schemas/gdi_userportal.yaml" \
+    "scheming.dataset_schemas = ckanext.dcat.schemas:health_dcat_ap.yaml ckanext.gdi_userportal:scheming/schemas/gdi_userportal.yaml ckanext.dataset_series.schemas:dcat_ap_dataset_series.yaml" \
     "scheming.presets = ckanext.scheming:presets.json ckanext.dcat.schemas:presets.yaml ckanext.gdi_userportal:scheming/presets/gdi_presets.yaml" \
     "scheming.dataset_fallback = false" \
-    "ckanext.dcat.rdf.profiles = euro_dcat_ap_3 euro_dcat_ap_scheming fairdatapoint_dcat_ap" \
+    "ckanext.dcat.rdf.profiles = euro_health_dcat_ap euro_dcat_ap_scheming fairdatapoint_dcat_ap" \
     "ckanext.dcat.compatibility_mode = false"
 
 

--- a/ckan/docker-entrypoint.d/setup_scheming.sh
+++ b/ckan/docker-entrypoint.d/setup_scheming.sh
@@ -7,7 +7,7 @@
 # Update the config file with each extension config-options
 echo "[ckanext-scheming] Setting up config-options"
 ckan config-tool $CKAN_INI -s app:main \
-    "scheming.dataset_schemas = ckanext.dcat.schemas:health_dcat_ap.yaml ckanext.gdi_userportal:scheming/schemas/gdi_userportal.yaml ckanext.dataset_series.schemas:dcat_ap_dataset_series.yaml" \
+    "scheming.dataset_schemas = ckanext.dcat.schemas:health_dcat_ap.yaml ckanext.gdi_userportal:scheming/schemas/gdi_userportal.yaml" \
     "scheming.presets = ckanext.scheming:presets.json ckanext.dcat.schemas:presets.yaml ckanext.gdi_userportal:scheming/presets/gdi_presets.yaml" \
     "scheming.dataset_fallback = false" \
     "ckanext.dcat.rdf.profiles = euro_health_dcat_ap euro_dcat_ap_scheming fairdatapoint_dcat_ap" \


### PR DESCRIPTION
## Summary by Sourcery

Update the CKAN configuration to use the health-specific DCAT schema and RDF profile, and upgrade the fairdatapoint extension to a newer version in the Docker setup.

Enhancements:
- Update the scheming dataset schema to use 'health_dcat_ap.yaml' instead of 'dcat_ap_full.yaml'.
- Change the RDF profiles to include 'euro_health_dcat_ap' instead of 'euro_dcat_ap_3'.

Build:
- Upgrade the 'gdi-userportal-ckanext-fairdatapoint' dependency from version 1.3.2 to 1.3.3 in the Dockerfile.