### PR TITLE
Patch extensions

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -10,9 +10,10 @@ USER root
 RUN chown -R ckan:ckan-sys ${APP_DIR}
 USER ckan
 
-RUN pip3 install -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-gdi-userportal.git@v1.5.0#egg=ckanext-gdi-userportal && \
+
+RUN pip3 install -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-gdi-userportal.git@v1.6.0#egg=ckanext-gdi-userportal && \
     pip3 install -r ${APP_DIR}/src/ckanext-gdi-userportal/requirements.txt && \
-    pip3 install -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-dcat.git@v2.3.1#egg=ckanext-dcat && \
+    pip3 install -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-dcat.git@v2.3.2#egg=ckanext-dcat && \
     pip3 install -r ${APP_DIR}/src/ckanext-dcat/requirements.txt && \
     pip3 install -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-dataset-series.git@v1.0.0#egg=ckanext-dataset-series && \
     pip3 install -r ${APP_DIR}/src/ckanext-dataset-series/requirements.txt && \

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -10,7 +10,7 @@ USER root
 RUN chown -R ckan:ckan-sys ${APP_DIR}
 USER ckan
 
-RUN pip3 install -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-dcat.git@v2.3.1#egg=ckanext-dcat && \
+RUN pip3 install -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-dcat.git@v2.3.2#egg=ckanext-dcat && \
     pip3 install -r ${APP_DIR}/src/ckanext-dcat/requirements.txt && \
     pip3 install -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-dataset-series.git@v1.0.0#egg=ckanext-dataset-series && \
     pip3 install -r ${APP_DIR}/src/ckanext-dataset-series/requirements.txt && \

--- a/ckan/docker-entrypoint.d/setup_scheming.sh
+++ b/ckan/docker-entrypoint.d/setup_scheming.sh
@@ -10,7 +10,7 @@ ckan config-tool $CKAN_INI -s app:main \
     "scheming.dataset_schemas = ckanext.dcat.schemas:health_dcat_ap.yaml ckanext.gdi_userportal:scheming/schemas/gdi_userportal.yaml ckanext.dcat.schemas:dcat_ap_dataset_series.yaml" \
     "scheming.presets = ckanext.scheming:presets.json ckanext.dcat.schemas:presets.yaml ckanext.gdi_userportal:scheming/presets/gdi_presets.yaml ckanext.dataset_series.schemas:presets.yaml" \
     "scheming.dataset_fallback = false" \
-    "ckanext.dcat.rdf.profiles = euro_health_dcat_ap euro_dcat_ap_scheming fairdatapoint_dcat_ap" \
+    "ckanext.dcat.rdf.profiles = fairdatapoint_dcat_ap" \
     "ckanext.dcat.compatibility_mode = false"
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,6 @@ services:
 
   ckan-dev:
     build:
-      platforms:
-        - linux/amd64
       context: ckan/
       dockerfile: Dockerfile.dev
       args:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
 
   ckan-dev:
     build:
+      platforms:
+        - linux/amd64
       context: ckan/
       dockerfile: Dockerfile.dev
       args:


### PR DESCRIPTION
Lot of new DCAT fields are added

## Summary by Sourcery

Refine CKAN extension setup by bumping extension versions, restricting DCAT profiles, and adding platform constraints for development

Enhancements:
- Restrict DCAT RDF profile to fairdatapoint_dcat_ap only

Build:
- Update ckanext-gdi-userportal to v1.6.0 and ckanext-dcat to v2.3.2 in the CKAN Dockerfile
- Add linux/amd64 platform specification for ckan-dev service in docker-compose