### PR TITLE
feat(readme) : Improved readme for setting up with Apple Sillicon lap…

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,13 @@ CKAN and all the components are configured using environment variables that you 
 * If you are using an Apple Silicon laptop (e.g., M1 or M2), add the following property to your `docker-compose.yml` file within ckan-dev service to ensure compatibility:
 
 ```yaml
-  platforms:
-    - linux/amd64
+services:
+
+  ckan-dev:
+    platform: linux/amd64
+    build:
+      context: ckan/
+      dockerfile: Dockerfile.dev
 ```
 
 ## 3. Useful commands


### PR DESCRIPTION
…top closes #192

## Summary by Sourcery

Improve README setup instructions for Apple Silicon laptops and correct submodule naming in git clone instructions.

Documentation:
- Update git submodule path reference from CKAN-DOCKER to gdi-userportal-ckan-docker
- Add Apple Silicon compatibility note with YAML snippet to set platform linux/amd64 in docker-compose.yml