### PR TITLE
Patch userportal

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -11,7 +11,7 @@ RUN chown -R ckan:ckan-sys ${APP_DIR}
 USER ckan
 
 
-RUN pip3 install -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-gdi-userportal.git@v1.6.0#egg=ckanext-gdi-userportal && \
+RUN pip3 install -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-gdi-userportal.git@v1.8.0#egg=ckanext-gdi-userportal && \
     pip3 install -r ${APP_DIR}/src/ckanext-gdi-userportal/requirements.txt && \
     pip3 install -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-dcat.git@v2.3.2#egg=ckanext-dcat && \
     pip3 install -r ${APP_DIR}/src/ckanext-dcat/requirements.txt && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,4 +78,4 @@ services:
     healthcheck:
       test: ["CMD", "redis-cli", "-e", "QUIT"]
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
 
   ckan-dev:
     build:
+      platforms:
+        - linux/amd64
       context: ckan/
       dockerfile: Dockerfile.dev
       args:
@@ -77,3 +79,5 @@ services:
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "redis-cli", "-e", "QUIT"]
+    ports:
+      - "6379:6379"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,6 @@ services:
 
   ckan-dev:
     build:
-      platforms:
-        - linux/amd64
       context: ckan/
       dockerfile: Dockerfile.dev
       args:


### PR DESCRIPTION
## Summary by Sourcery

Update Docker configuration and bump gdi-userportal extension version to improve local development compatibility

Enhancements:
- Specify linux/amd64 platform for ckan-dev build in docker-compose
- Expose Redis default port in docker-compose for external access
- Upgrade gdi-userportal CKAN extension from v1.6.0 to v1.8.0