### PR TITLE
chore: update gdi-userportal extension to v1.11.15 and add script for term translation migrations on startup

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -18,7 +18,7 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
 RUN set -eux; \
     python -m pip install --upgrade --no-cache-dir pip setuptools wheel; \
     python -m pip install --no-cache-dir \
-        -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-gdi-userportal.git@v1.11.14#egg=ckanext-gdi-userportal \
+        -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-gdi-userportal.git@v1.11.15#egg=ckanext-gdi-userportal \
         -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-dcat.git@v2.3.9#egg=ckanext-dcat \
         -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-dataset-series.git@v1.0.0#egg=ckanext-dataset-series \
         -e git+https://github.com/ckan/ckanext-harvest.git@v1.6.2#egg=ckanext-harvest \

--- a/ckan/docker-entrypoint.d/03_run_translations_migrations.sh
+++ b/ckan/docker-entrypoint.d/03_run_translations_migrations.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2024 Stichting Health-RI
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Run term translation migrations on startup
+# This ensures all required translations are present in the database
+
+set -e
+
+echo "=== Running term translation migrations ==="
+
+# Wait for database to be ready (handled by previous scripts, but just in case)
+if [ -z "$CKAN_SQLALCHEMY_URL" ]; then
+    echo "Warning: CKAN_SQLALCHEMY_URL not set, skipping migrations"
+    exit 0
+fi
+
+# Run migrations using the CKAN CLI
+# The --config flag ensures we use the correct CKAN config
+if command -v ckan &> /dev/null; then
+    echo "Running: ckan gdi-userportal translations migrate"
+    ckan -c /srv/app/ckan.ini gdi-userportal translations migrate || {
+        echo "Warning: Term translation migrations failed, but continuing startup"
+        echo "You can run migrations manually with: ckan gdi-userportal translations migrate"
+    }
+    echo "=== Term translation migrations complete ==="
+else
+    echo "Warning: CKAN CLI not available, skipping term translation migrations"
+    echo "Run manually after startup: ckan gdi-userportal translations migrate"
+fi


### PR DESCRIPTION
## Summary by Sourcery

Update the CKAN Docker image to use the latest gdi-userportal extension version and automatically run term translation migrations on container startup.

Enhancements:
- Bump the gdi-userportal CKAN extension dependency from v1.11.14 to v1.11.15.
- Add a startup script to execute gdi-userportal term translation migrations via the CKAN CLI, with graceful handling when the database or CLI are unavailable.