### PR TITLE
chore: update gdi-userportal ckan-ext

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -18,25 +18,25 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
 RUN set -eux; \
     python -m pip install --upgrade --no-cache-dir pip setuptools wheel; \
     python -m pip install --no-cache-dir \
-        -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-gdi-userportal.git@v1.11.11#egg=ckanext-gdi-userportal \
-        -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-dcat.git@v2.3.9#egg=ckanext-dcat \
-        -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-dataset-series.git@v1.0.0#egg=ckanext-dataset-series \
-        -e git+https://github.com/ckan/ckanext-harvest.git@v1.6.1#egg=ckanext-harvest \
-        'ckanext-scheming[requirements] @ git+https://github.com/ckan/ckanext-scheming.git@release-3.1.0' \
-        -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-fairdatapoint.git@v1.6.6#egg=ckanext-fairdatapoint \
-        -e git+https://github.com/ckan/ckanext-fluent.git#egg=ckanext-fluent; \
+    -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-gdi-userportal.git@v1.11.19#egg=ckanext-gdi-userportal \
+    -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-dcat.git@v2.3.9#egg=ckanext-dcat \
+    -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-dataset-series.git@v1.0.0#egg=ckanext-dataset-series \
+    -e git+https://github.com/ckan/ckanext-harvest.git@v1.6.1#egg=ckanext-harvest \
+    'ckanext-scheming[requirements] @ git+https://github.com/ckan/ckanext-scheming.git@release-3.1.0' \
+    -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-fairdatapoint.git@v1.6.6#egg=ckanext-fairdatapoint \
+    -e git+https://github.com/ckan/ckanext-fluent.git#egg=ckanext-fluent; \
     for requirement in \
-        ckanext-gdi-userportal \
-        ckanext-dcat \
-        ckanext-dataset-series \
-        ckanext-harvest \
-        ckanext-fairdatapoint \
-        ckanext-fluent \
+    ckanext-gdi-userportal \
+    ckanext-dcat \
+    ckanext-dataset-series \
+    ckanext-harvest \
+    ckanext-fairdatapoint \
+    ckanext-fluent \
     ; do \
-        req_file="${APP_DIR}/src/${requirement}/requirements.txt"; \
-        if [ -f "${req_file}" ]; then \
-            python -m pip install --no-cache-dir -r "${req_file}"; \
-        fi; \
+    req_file="${APP_DIR}/src/${requirement}/requirements.txt"; \
+    if [ -f "${req_file}" ]; then \
+    python -m pip install --no-cache-dir -r "${req_file}"; \
+    fi; \
     done; \
     python -m pip check
 


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Bump ckanext-gdi-userportal dependency in the CKAN Dockerfile from v1.11.11 to v1.11.19.