### PR TITLE
Use official ckanext-dataset-series repo

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -20,7 +20,7 @@ RUN set -eux; \
     python -m pip install --no-cache-dir \
         -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-gdi-userportal.git@v1.11.19#egg=ckanext-gdi-userportal \
         -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-dcat.git@v2.4.0#egg=ckanext-dcat \
-        -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-dataset-series.git@v1.0.0#egg=ckanext-dataset-series \
+        -e git+https://github.com/ckan/ckanext-dataset-series.git#egg=ckanext-dataset-series \
         -e git+https://github.com/ckan/ckanext-harvest.git@v1.6.2#egg=ckanext-harvest \
         'ckanext-scheming[requirements] @ git+https://github.com/ckan/ckanext-scheming.git@release-3.1.0' \
         -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-fairdatapoint.git@v1.6.10#egg=ckanext-fairdatapoint \

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -20,7 +20,7 @@ RUN set -eux; \
     python -m pip install --no-cache-dir \
         -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-gdi-userportal.git@v1.11.19#egg=ckanext-gdi-userportal \
         -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-dcat.git@v2.4.0#egg=ckanext-dcat \
-        -e git+https://github.com/ckan/ckanext-dataset-series.git#egg=ckanext-dataset-series \
+        -e git+https://github.com/ckan/ckanext-dataset-series.git@v0.1.1#egg=ckanext-dataset-series \
         -e git+https://github.com/ckan/ckanext-harvest.git@v1.6.2#egg=ckanext-harvest \
         'ckanext-scheming[requirements] @ git+https://github.com/ckan/ckanext-scheming.git@release-3.1.0' \
         -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-fairdatapoint.git@v1.6.10#egg=ckanext-fairdatapoint \

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -19,7 +19,7 @@ RUN set -eux; \
     python -m pip install --upgrade --no-cache-dir pip setuptools wheel; \
     python -m pip install --no-cache-dir \
         -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-dcat.git@v2.4.0#egg=ckanext-dcat \
-        -e git+https://github.com/ckan/ckanext-dataset-series.git#egg=ckanext-dataset-series \
+        -e git+https://github.com/ckan/ckanext-dataset-series.git@v0.1.1#egg=ckanext-dataset-series \
         -e git+https://github.com/ckan/ckanext-harvest.git@v1.6.2#egg=ckanext-harvest \
         'ckanext-scheming[requirements] @ git+https://github.com/ckan/ckanext-scheming.git@release-3.1.0' \
         -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-fairdatapoint.git@v1.6.10#egg=ckanext-fairdatapoint \

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -19,7 +19,7 @@ RUN set -eux; \
     python -m pip install --upgrade --no-cache-dir pip setuptools wheel; \
     python -m pip install --no-cache-dir \
         -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-dcat.git@v2.4.0#egg=ckanext-dcat \
-        -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-dataset-series.git@v1.0.0#egg=ckanext-dataset-series \
+        -e git+https://github.com/ckan/ckanext-dataset-series.git#egg=ckanext-dataset-series \
         -e git+https://github.com/ckan/ckanext-harvest.git@v1.6.2#egg=ckanext-harvest \
         'ckanext-scheming[requirements] @ git+https://github.com/ckan/ckanext-scheming.git@release-3.1.0' \
         -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-fairdatapoint.git@v1.6.10#egg=ckanext-fairdatapoint \


### PR DESCRIPTION
Replace the GDI fork of ckanext-dataset-series with the upstream ckan/ckanext-dataset-series repository in ckan/Dockerfile and ckan/Dockerfile.dev. The pip install lines now point to the official repo (removing the previous @v1.0.0 GDI fork), aligning the Docker images with the upstream extension source.

## Summary by Sourcery

Build:
- Update CKAN and CKAN dev Dockerfiles to reference the official ckan/ckanext-dataset-series Git repository in pip install.