### PR TITLE
Patch userportal extension

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -18,7 +18,7 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
 RUN set -eux; \
     python -m pip install --upgrade --no-cache-dir pip setuptools wheel; \
     python -m pip install --no-cache-dir \
-        -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-gdi-userportal.git@v1.11.19#egg=ckanext-gdi-userportal \
+        -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-gdi-userportal.git@v1.11.21#egg=ckanext-gdi-userportal \
         -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-dcat.git@v2.4.0#egg=ckanext-dcat \
         -e git+https://github.com/ckan/ckanext-dataset-series.git@v0.1.1#egg=ckanext-dataset-series \
         -e git+https://github.com/ckan/ckanext-harvest.git@v1.6.2#egg=ckanext-harvest \


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Bump gdi-userportal CKAN extension dependency from v1.11.19 to v1.11.21 in the CKAN Dockerfile.