### PR TITLE
Add OTLP gRPC exporter to CKAN image

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -17,6 +17,9 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
 
 RUN set -eux; \
     python -m pip install --upgrade --no-cache-dir pip setuptools wheel; \
+    # Match the OTEL packages already bundled in the base image and add gRPC export support for ACA.
+    python -m pip install --no-cache-dir \
+        opentelemetry-exporter-otlp-proto-grpc==1.39.1; \
     python -m pip install --no-cache-dir \
         -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-gdi-userportal.git@v1.11.21#egg=ckanext-gdi-userportal \
         -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-dcat.git@v2.4.0#egg=ckanext-dcat \


### PR DESCRIPTION
## Summary
- install the OTLP gRPC exporter package in the CKAN image
- match the existing OpenTelemetry package version already present in the base image
- enable the image to use Azure Container Apps' reachable gRPC collector endpoint on port 4317

## Why
The current image contains the OpenTelemetry SDK and HTTP OTLP exporter, but not the gRPC OTLP exporter. In Azure Container Apps, the managed OpenTelemetry agent only supports gRPC, and from the live CKAN container the reachable collector port is 4317. Without the gRPC exporter package, CKAN cannot export traces successfully in ACA.
