### PR TITLE
chore: update Azure deployment configuration and subproject reference

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,6 @@ permissions: {}
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ghcr.io/genomicdatainfrastructure/gdi-userportal-ckan-docker
-  AZURE_WEBAPP_NAME: ckan-test
 
 jobs:
   ort:
@@ -105,11 +104,3 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Deploy to Azure Web App
-        id: deploy-to-webapp
-        uses: azure/webapps-deploy@02a81bead70021f5284939794bcec79c271ab383 # v3.0.8
-        with:
-          app-name: ${{ env.AZURE_WEBAPP_NAME }}
-          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
-          images: "${{ steps.tag.outputs.last_tag }}"


### PR DESCRIPTION
## Summary by Sourcery

Remove Azure Web App deployment from the main GitHub Actions workflow and update the ckanext-gdi-userportal subproject reference.

CI:
- Remove the Azure Web App deployment step and related environment configuration from the main workflow.

Deployment:
- Stop deploying the container image to the configured Azure Web App via GitHub Actions.

Chores:
- Update the ckanext-gdi-userportal subproject reference to a newer revision.