### PR TITLE
Fix cron startup in Container Apps

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -58,13 +58,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY config/supervisord.conf /etc/supervisord.d/ckan.conf
 COPY config/crontab /etc/cron.d/ckan-cron
 
-# Cron needs a writable pid directory at runtime.
-# Container Apps runs this image as the ckan user, so replace the /var/run
-# symlink with a real directory owned by ckan before installing the crontab.
-RUN rm -rf /var/run && \
-    mkdir -p /var/run && \
-    chown ckan:ckan-sys /var/run && \
-    chmod 0775 /var/run && \
+RUN install -d -o ckan -g ckan-sys -m 0775 /var/run/ckan && \
+    touch /var/run/ckan/crond.pid /var/run/ckan/crond.reboot && \
+    chown ckan:ckan-sys /var/run/ckan/crond.pid /var/run/ckan/crond.reboot && \
+    ln -sfn /var/run/ckan/crond.pid /var/run/crond.pid && \
+    ln -sfn /var/run/ckan/crond.reboot /var/run/crond.reboot && \
     chmod gu+s /usr/sbin/cron && \
     crontab -u ckan /etc/cron.d/ckan-cron
 

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -58,8 +58,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY config/supervisord.conf /etc/supervisord.d/ckan.conf
 COPY config/crontab /etc/cron.d/ckan-cron
 
-# Running cron as non-root user and give permission to ckan user
-RUN chmod gu+rw /var/run && \
+# Cron needs a writable pid directory at runtime.
+# Container Apps runs this image as the ckan user, so replace the /var/run
+# symlink with a real directory owned by ckan before installing the crontab.
+RUN rm -rf /var/run && \
+    mkdir -p /var/run && \
+    chown ckan:ckan-sys /var/run && \
+    chmod 0775 /var/run && \
     chmod gu+s /usr/sbin/cron && \
     crontab -u ckan /etc/cron.d/ckan-cron
 

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -53,13 +53,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY config/supervisord.conf /etc/supervisord.d/ckan.conf
 COPY config/crontab /etc/cron.d/ckan-cron
 
-# Cron needs a writable pid directory at runtime.
-# Container Apps runs this image as the ckan user, so replace the /var/run
-# symlink with a real directory owned by ckan before installing the crontab.
-RUN rm -rf /var/run && \
-    mkdir -p /var/run && \
-    chown ckan:ckan-sys /var/run && \
-    chmod 0775 /var/run && \
+RUN install -d -o ckan -g ckan-sys -m 0775 /var/run/ckan && \
+    touch /var/run/ckan/crond.pid /var/run/ckan/crond.reboot && \
+    chown ckan:ckan-sys /var/run/ckan/crond.pid /var/run/ckan/crond.reboot && \
+    ln -sfn /var/run/ckan/crond.pid /var/run/crond.pid && \
+    ln -sfn /var/run/ckan/crond.reboot /var/run/crond.reboot && \
     chmod gu+s /usr/sbin/cron && \
     crontab -u ckan /etc/cron.d/ckan-cron
 

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -53,8 +53,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY config/supervisord.conf /etc/supervisord.d/ckan.conf
 COPY config/crontab /etc/cron.d/ckan-cron
 
-# Running cron as non-root user and give permission to ckan user
-RUN chmod gu+rw /var/run && \
+# Cron needs a writable pid directory at runtime.
+# Container Apps runs this image as the ckan user, so replace the /var/run
+# symlink with a real directory owned by ckan before installing the crontab.
+RUN rm -rf /var/run && \
+    mkdir -p /var/run && \
+    chown ckan:ckan-sys /var/run && \
+    chmod 0775 /var/run && \
     chmod gu+s /usr/sbin/cron && \
     crontab -u ckan /etc/cron.d/ckan-cron
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,9 +54,7 @@ services:
       - CKAN_DB_PASSWORD
       - CKAN_DB
     volumes:
-      # PostgreSQL 18 expects the data directory under /var/lib/postgresql.
-      # Mount the parent directory so the image can manage its versioned subdir.
-      - pg_data:/var/lib/postgresql
+      - pg_data:/var/lib/postgresql/data
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,9 @@ services:
       - CKAN_DB_PASSWORD
       - CKAN_DB
     volumes:
-      - pg_data:/var/lib/postgresql/data
+      # PostgreSQL 18 expects the data directory under /var/lib/postgresql.
+      # Mount the parent directory so the image can manage its versioned subdir.
+      - pg_data:/var/lib/postgresql
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "${POSTGRES_USER}", "-d", "${POSTGRES_DB}"]

--- a/postgresql/Dockerfile
+++ b/postgresql/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-FROM docker.io/postgres:18-alpine
+FROM docker.io/postgres:18.4-alpine3.22
 
 # Include extra setup scripts (eg datastore)
 COPY --chown=postgres:postgres docker-entrypoint-initdb.d /docker-entrypoint-initdb.d


### PR DESCRIPTION
Root cause: the CKAN container was running entirely as the non-root `ckan` user in Azure Container Apps, but cron needs root privileges to start and was failing with "seteuid: Operation not permitted".

What changed:
- Run the container runtime as root so cron can start normally.
- Start `supervisord` once during CKAN startup.
- Start the CKAN web process as `ckan` from the entrypoint.
- Run the harvest gather/fetch consumers as `ckan` via supervisord.
- Install the harvest schedule as the `ckan` user's crontab.
- Mount Postgres data at `/var/lib/postgresql` so the PostgreSQL 18 image can manage its versioned data directory.

Validation:
- Deployed to ACC and verified the new revision is healthy.
- Confirmed `cron`, `supervisord`, `uwsgi`, `ckan_gather_consumer`, and `ckan_fetch_consumer` are all running.
- Confirmed the fetch consumer is actively processing harvest objects.
