### PR TITLE
Clean up CKAN cron startup

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -85,3 +85,5 @@ RUN for d in $APP_DIR/patches/*; do \
     done ; \
     fi ; \
     done
+
+USER root

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -58,13 +58,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY config/supervisord.conf /etc/supervisord.d/ckan.conf
 COPY config/crontab /etc/cron.d/ckan-cron
 
-RUN install -d -o ckan -g ckan-sys -m 0775 /var/run/ckan && \
-    touch /var/run/ckan/crond.pid /var/run/ckan/crond.reboot && \
-    chown ckan:ckan-sys /var/run/ckan/crond.pid /var/run/ckan/crond.reboot && \
-    ln -sfn /var/run/ckan/crond.pid /var/run/crond.pid && \
-    ln -sfn /var/run/ckan/crond.reboot /var/run/crond.reboot && \
-    chmod gu+s /usr/sbin/cron && \
-    crontab -u ckan /etc/cron.d/ckan-cron
+RUN crontab -u ckan /etc/cron.d/ckan-cron
 
 COPY --chown=ckan-sys:ckan-sys docker-entrypoint.d/* /docker-entrypoint.d/
 COPY --chown=ckan-sys:ckan-sys patches ${APP_DIR}/patches

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -80,3 +80,5 @@ RUN for d in $APP_DIR/patches/*; do \
     done ; \
     fi ; \
     done
+
+USER root

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -53,13 +53,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY config/supervisord.conf /etc/supervisord.d/ckan.conf
 COPY config/crontab /etc/cron.d/ckan-cron
 
-RUN install -d -o ckan -g ckan-sys -m 0775 /var/run/ckan && \
-    touch /var/run/ckan/crond.pid /var/run/ckan/crond.reboot && \
-    chown ckan:ckan-sys /var/run/ckan/crond.pid /var/run/ckan/crond.reboot && \
-    ln -sfn /var/run/ckan/crond.pid /var/run/crond.pid && \
-    ln -sfn /var/run/ckan/crond.reboot /var/run/crond.reboot && \
-    chmod gu+s /usr/sbin/cron && \
-    crontab -u ckan /etc/cron.d/ckan-cron
+RUN crontab -u ckan /etc/cron.d/ckan-cron
 
 COPY --chown=ckan-sys:ckan-sys docker-entrypoint.d/* /docker-entrypoint.d/
 COPY --chown=ckan-sys:ckan-sys patches ${APP_DIR}/patches

--- a/ckan/config/supervisord.conf
+++ b/ckan/config/supervisord.conf
@@ -17,8 +17,7 @@ minfds=1024
 minprocs=200
 
 [program:ckan_gather_consumer]
-command=/usr/local/bin/ckan --config=/srv/app/ckan.ini harvester gather-consumer
-user=ckan
+command=runuser -u ckan -- /usr/local/bin/ckan --config=/srv/app/ckan.ini harvester gather-consumer
 numprocs=1
 stdout_logfile=/var/log/ckan/std/gather_consumer.log
 stderr_logfile=/var/log/ckan/std/gather_consumer.log
@@ -27,8 +26,7 @@ autorestart=true
 startsecs=10
 
 [program:ckan_fetch_consumer]
-command=/usr/local/bin/ckan --config=/srv/app/ckan.ini harvester fetch-consumer
-user=ckan
+command=runuser -u ckan -- /usr/local/bin/ckan --config=/srv/app/ckan.ini harvester fetch-consumer
 numprocs=1
 stdout_logfile=/var/log/ckan/std/fetch_consumer.log
 stderr_logfile=/var/log/ckan/std/fetch_consumer.log

--- a/ckan/config/supervisord.conf
+++ b/ckan/config/supervisord.conf
@@ -18,6 +18,7 @@ minprocs=200
 
 [program:ckan_gather_consumer]
 command=/usr/local/bin/ckan --config=/srv/app/ckan.ini harvester gather-consumer
+user=ckan
 numprocs=1
 stdout_logfile=/var/log/ckan/std/gather_consumer.log
 stderr_logfile=/var/log/ckan/std/gather_consumer.log
@@ -27,6 +28,7 @@ startsecs=10
 
 [program:ckan_fetch_consumer]
 command=/usr/local/bin/ckan --config=/srv/app/ckan.ini harvester fetch-consumer
+user=ckan
 numprocs=1
 stdout_logfile=/var/log/ckan/std/fetch_consumer.log
 stderr_logfile=/var/log/ckan/std/fetch_consumer.log
@@ -45,4 +47,3 @@ startsecs=10
 
 [include]
 files = /etc/supervisor/conf.d/*.conf
-

--- a/ckan/setup/start_ckan.sh
+++ b/ckan/setup/start_ckan.sh
@@ -57,8 +57,12 @@ UWSGI_OPTS="--socket /tmp/uwsgi.sock \
 if [ $? -eq 0 ]
 then
     supervisord --configuration /etc/supervisord.d/ckan.conf & 
-    # Start uwsgi
-    uwsgi $UWSGI_OPTS
+    # Start uwsgi as ckan while keeping the container runtime root for cron.
+    if command -v runuser >/dev/null 2>&1; then
+        runuser -u ckan -- sh -lc "uwsgi $UWSGI_OPTS"
+    else
+        su -s /bin/sh ckan -c "uwsgi $UWSGI_OPTS"
+    fi
 else
   echo "[prerun] failed...not starting CKAN."
 fi

--- a/ckan/setup/start_ckan.sh
+++ b/ckan/setup/start_ckan.sh
@@ -56,7 +56,7 @@ UWSGI_OPTS="--socket /tmp/uwsgi.sock \
 
 if [ $? -eq 0 ]
 then
-    supervisord --configuration /etc/supervisord.d/ckan.conf & 
+    supervisord --configuration /etc/supervisord.d/ckan.conf
     # Start uwsgi as ckan while keeping the container runtime root for cron.
     if command -v runuser >/dev/null 2>&1; then
         runuser -u ckan -- sh -lc "uwsgi $UWSGI_OPTS"

--- a/ckan/setup/start_ckan_development.sh
+++ b/ckan/setup/start_ckan_development.sh
@@ -78,7 +78,11 @@ fi
 # Start the development server as the ckan user with automatic reload
 while true; do
     supervisord --configuration /etc/supervisord.d/ckan.conf & 
-    $CKAN_RUN $CKAN_OPTIONS
+    if command -v runuser >/dev/null 2>&1; then
+        runuser -u ckan -- sh -lc "$CKAN_RUN $CKAN_OPTIONS"
+    else
+        su -s /bin/sh ckan -c "$CKAN_RUN $CKAN_OPTIONS"
+    fi
     echo Exit with status $?. Restarting.
     sleep 2
 done

--- a/ckan/setup/start_ckan_development.sh
+++ b/ckan/setup/start_ckan_development.sh
@@ -75,9 +75,10 @@ if [ "$USE_HTTPS_FOR_DEV" = true ] ; then
     CKAN_OPTIONS="$CKAN_OPTIONS -C unsafe.cert -K unsafe.key"
 fi
 
+supervisord --configuration /etc/supervisord.d/ckan.conf
+
 # Start the development server as the ckan user with automatic reload
 while true; do
-    supervisord --configuration /etc/supervisord.d/ckan.conf & 
     if command -v runuser >/dev/null 2>&1; then
         runuser -u ckan -- sh -lc "$CKAN_RUN $CKAN_OPTIONS"
     else


### PR DESCRIPTION
Summary
- Remove the /var/run/ckan cron pid-file workaround from both CKAN Dockerfiles.
- Run the container runtime as root so cron can start normally.
- Keep uwsgi and harvest consumers running as the ckan user.
- Start supervisord once instead of from the development restart loop.

Validation
- bash -n ckan/setup/start_ckan.sh ckan/setup/start_ckan_development.sh
- git diff --check origin/main...HEAD
- docker buildx build --platform linux/amd64 --load -t ckan-clean-cron-test ./ckan

Note: PR #304 was already merged, so this is a follow-up cleanup PR with the final ACC-validated runtime changes.