### PR TITLE
[codex] Bump userportal extension to v1.11.27

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -18,7 +18,7 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
 RUN set -eux; \
     python -m pip install --upgrade --no-cache-dir pip setuptools wheel; \
     python -m pip install --no-cache-dir \
-        -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-gdi-userportal.git@v1.11.26#egg=ckanext-gdi-userportal \
+        -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-gdi-userportal.git@v1.11.27#egg=ckanext-gdi-userportal \
         -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-dcat.git@v2.4.2#egg=ckanext-dcat \
         -e git+https://github.com/ckan/ckanext-dataset-series.git@v0.1.1#egg=ckanext-dataset-series \
         -e git+https://github.com/ckan/ckanext-harvest.git@v1.6.2#egg=ckanext-harvest \


### PR DESCRIPTION
## What changed
- Bumped the Dockerfile install reference for `ckanext-gdi-userportal` from `v1.11.26` to `v1.11.27`.
- Updated the `src/ckanext-gdi-userportal` submodule pointer to the matching `v1.11.27` commit.

## Why
Keeps the Docker image dependency and checked-out extension source aligned on the latest userportal extension release.

## Validation
- Verified the submodule `HEAD` is exactly tag `v1.11.27`.
- Verified the committed diff is limited to `ckan/Dockerfile` and `src/ckanext-gdi-userportal`.

No runtime tests were run; this PR only updates the pinned extension version.

## Summary by Sourcery

Align the CKAN Docker image and submodule with the latest gdi-userportal extension release.

Enhancements:
- Update the CKAN Dockerfile to install ckanext-gdi-userportal version v1.11.27.
- Advance the ckanext-gdi-userportal submodule to the corresponding v1.11.27 commit to keep source and image dependencies in sync.